### PR TITLE
Remove "repo_owner" from workflow files and add Ben as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*       @merveenoyan @johko @lunarflu
+*       @merveenoyan @johko @lunarflu @burtenshaw
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies files in /chapters/ or /notebooks/, only the here mentioned 
 # and not the global owner(s) will be requested for a review.
 
-/chapters/    @merveenoyan @johko
+/chapters/    @merveenoyan @johko @burtenshaw
 
-/notebooks/    @merveenoyan @johko
+/notebooks/    @merveenoyan @johko @burtenshaw

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -12,7 +12,6 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: computer-vision-course
       package_name: computer-vision-course
-      repo_owner: johko
       path_to_docs: computer-vision-course/chapters/
       additional_args: --not_python_module
       languages: en

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,7 +15,6 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: computer-vision-course
       package_name: computer-vision-course
-      repo_owner: johko
       path_to_docs: computer-vision-course/chapters/
       additional_args: --not_python_module
       languages: en


### PR DESCRIPTION
I removed the `repo_owner` attribute from the workflow files, as the repo now lives in the Huggingface org.

Additionally, as discussed, I added Ben(@burtenshaw) as a codeowner