### PR TITLE
Unit2 (CNN)/YOLO/RCNN fix image incorrect link

### DIFF
--- a/chapters/en/unit2/cnns/yolo.mdx
+++ b/chapters/en/unit2/cnns/yolo.mdx
@@ -24,7 +24,7 @@ For training purpose, the paper proposed the following steps
 3. Then use the fine tuned model on the object detection dataset. 
 
 The following is a basic pipeline of RCNN 
-![rcnn](https://huggingface.co/datasets/hf-vision/course-assets/resolve/main/Fast%20R-CNN.png)
+![rcnn](https://huggingface.co/datasets/hf-vision/course-assets/resolve/main/RCNN.png)
 
 
 #### Fast RCNN 


### PR DESCRIPTION
There was a simple copy paste typo, this fixes it
Note the rcnn image is correct