### PR TITLE
Fix variable name from 'images' to 'inputs'

### DIFF
--- a/chapters/en/unit3/vision-transformers/vision-transformers-for-image-segmentation.mdx
+++ b/chapters/en/unit3/vision-transformers/vision-transformers-for-image-segmentation.mdx
@@ -56,7 +56,7 @@ segmentation = pipeline("image-segmentation", "facebook/maskformer-swin-base-coc
 url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 image = Image.open(requests.get(url, stream=True).raw)
 
-results = segmentation(images=image, subtask="panoptic")
+results = segmentation(inputs=image, subtask="panoptic")
 results
 ```
 


### PR DESCRIPTION
The example doesn't seem to work anymore. It seems the parameter name "images" was changed to "input".

Tested with transformers==4.56.0